### PR TITLE
[add]動かすための設定にymlファイルを用いる　&& コマンドライン引数の解析方法の実装変更

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,6 +76,7 @@ dependencies = [
  "clap 2.31.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "yaml-rust 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -281,6 +282,11 @@ dependencies = [
  "byteorder 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "crc 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "log"
@@ -829,6 +835,14 @@ dependencies = [
  "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
+[[package]]
+name = "yaml-rust"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "linked-hash-map 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
 [metadata]
 "checksum adler32 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6cbd0b9af8587c72beadc9f72d35b9fbb070982c9e6203e46e93f10df25f8f45"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
@@ -866,6 +880,7 @@ dependencies = [
 "checksum lazycell 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a6f08839bc70ef4a3fe1d566d5350f519c5912ea86be0df1740a7d247c7fc0ef"
 "checksum libc 0.2.39 (registry+https://github.com/rust-lang/crates.io-index)" = "f54263ad99207254cf58b5f701ecb432c717445ea2ee8af387334bdd1a03fdff"
 "checksum libflate 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "1a429b86418868c7ea91ee50e9170683f47fd9d94f5375438ec86ec3adb74e8e"
+"checksum linked-hash-map 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "70fb39025bc7cdd76305867c4eccf2f2dcf6e9a57f5b21a93e1c2d86cd03ec9e"
 "checksum log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
 "checksum log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "89f010e843f2b1a31dbd316b3b8d443758bc634bed37aabade59c686d644e0a2"
 "checksum matches 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "100aabe6b8ff4e4a7e32c1c13523379802df0772b82466207ac25b013f193376"
@@ -931,3 +946,4 @@ dependencies = [
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 "checksum ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
+"checksum yaml-rust 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "57ab38ee1a4a266ed033496cf9af1828d8d6e6c1cfa5f643a2809effcae4d628"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,4 +7,5 @@ authors = ["ItinoseSan <dhelitus@gmail.com>"]
 reqwest = "*"
 clap = "2.31.1"
 serde_json = "1.0"
+yaml-rust = "0.4"
 

--- a/README.md
+++ b/README.md
@@ -10,12 +10,19 @@ Toy CLI tool which can check github user information that implemented in Rust La
 git clone git@github.com:ItinoseSan/check-hub.git
 cd check-hub
 ```
-2.Please edit value of ```src/github_api.rs```
-```rust
-const GITHUB_USER_NAME:&str = "Your github user name";
-const API_TOKEN:&str = "Your token";
+2.Please touch ```apiconfig.yml```  config file  in ```target/debug```
 ```
-3.Build project 
+cd target/debug
+touch apiconfig.yml
+```
+3.Edit this yml file like a below
+
+```yaml
+name: <github login name>
+GITHUB_API_TOKEN: YOUR_GITHUB_API_TOKEN
+```
+
+4.Build project 
 ```
 cargo build
 ```

--- a/src/github_api.rs
+++ b/src/github_api.rs
@@ -1,18 +1,43 @@
+#[allow(unused_must_use)]
+#[warn(unused_must_use)]
 use std::mem;
+use std::fs;
+use std::fs::File;
+use std::io::Read;
+
+
 
 const API_BASE_URL:&str = "https://api.github.com/";
-const GITHUB_USER_NAME:&str = "Your user name";
-const API_TOKEN:&str = "Your token";
 
+pub fn get_token(filename: &str)->&str{
+    let mut token = String::new();
+    File::open(filename).unwrap().read_to_string(&mut token).unwrap();
+    string_to_static_str(token)
+}
+
+pub fn get_name(filename: &str)->&str{
+    let mut username = String::new();
+    File::open(filename).unwrap().read_to_string(&mut username).unwrap();
+    string_to_static_str(username)
+}
+
+fn string_to_static_str(s: String) -> &'static str { //  ReadLine's String convert to static str
+    unsafe {
+        let ret = mem::transmute(&s as &str);
+        mem::forget(s);
+        ret
+    }
+}
 pub struct GithubAPI{}
 
 impl GithubAPI{
     pub fn new() -> GithubAPI{
         GithubAPI {}
     }
+    
     pub fn profile(&self)-> &str{
-        let username = GITHUB_USER_NAME;
-        let token = API_TOKEN; 
+        let username = get_name("NameFile");
+        let token = get_token("TokenFile");
         let url = format!(
             "{}{}{}{}{}",API_BASE_URL,"users/",username,"?accesstoken=",token
         );

--- a/src/github_api.rs
+++ b/src/github_api.rs
@@ -1,43 +1,41 @@
-#[allow(unused_must_use)]
-#[warn(unused_must_use)]
+extern crate yaml_rust;
+use yaml_rust::{YamlLoader, YamlEmitter};
+
 use std::mem;
 use std::fs;
 use std::fs::File;
 use std::io::Read;
 
-
-
 const API_BASE_URL:&str = "https://api.github.com/";
 
-pub fn get_token(filename: &str)->&str{
-    let mut token = String::new();
-    File::open(filename).unwrap().read_to_string(&mut token).unwrap();
-    string_to_static_str(token)
+pub fn get_config_yamlfile(filename: &str) ->&str{
+    let mut file = String::new();
+    File::open(filename).unwrap().read_to_string(&mut file).unwrap();
+    string_to_static_str(file)
 }
-
-pub fn get_name(filename: &str)->&str{
-    let mut username = String::new();
-    File::open(filename).unwrap().read_to_string(&mut username).unwrap();
-    string_to_static_str(username)
-}
-
-fn string_to_static_str(s: String) -> &'static str { //  ReadLine's String convert to static str
+fn string_to_static_str(s: String) -> &'static str { 
     unsafe {
         let ret = mem::transmute(&s as &str);
         mem::forget(s);
         ret
     }
 }
+
 pub struct GithubAPI{}
 
 impl GithubAPI{
     pub fn new() -> GithubAPI{
         GithubAPI {}
     }
-    
     pub fn profile(&self)-> &str{
-        let username = get_name("NameFile");
-        let token = get_token("TokenFile");
+        let yaml = get_config_yamlfile("apiconfig.yml");
+        let load_yaml = YamlLoader::load_from_str(yaml).unwrap();
+        let yaml_parser = &load_yaml[0];
+        let name_result = yaml_parser["name"].as_str().unwrap();
+        let token_result = yaml_parser["GITHUB_API_TOKEN"].as_str().unwrap();
+        let  username :&str = name_result;
+        let token :&str = token_result;
+
         let url = format!(
             "{}{}{}{}{}",API_BASE_URL,"users/",username,"?accesstoken=",token
         );

--- a/src/http.rs
+++ b/src/http.rs
@@ -12,9 +12,9 @@ impl HttpRequest{
         let mut resp = reqwest::get(url).unwrap();
         let mut s = String::new();
         resp.read_to_string(&mut s);
-        return self.convert_to_statictype(s);
+        return self.cast_typeof_response(s);
     }
-    fn convert_to_statictype(&self,s: String) -> &str { // String convert to static str
+    fn cast_typeof_response(&self,s: String) -> &str { // String convert to static str
         unsafe {
             let ret = mem::transmute(&s as &str);
             mem::forget(s);

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,8 @@ use github_api::GithubAPI;
 use http::HttpRequest;
 use json::JSON;
 
+extern crate yaml_rust;
+use yaml_rust::{YamlLoader, YamlEmitter};
 
 pub struct Checkhub{}
 
@@ -33,9 +35,9 @@ impl Checkhub{
         - location") 
        .required(true)          
     );
-    self.parse_command(tool);      
+    self.parse_argument(tool);      
     }                                                    
-    fn parse_command(&self,tool: App){
+    fn parse_argument(&self,tool: App){
         let github = GithubAPI::new();
         let client = HttpRequest::new();
         let url = github.profile();
@@ -44,29 +46,51 @@ impl Checkhub{
         let maches = tool.get_matches();
       
         if let Some(arg) = maches.value_of("INFO NAME"){
-            let name :&str = "name";
-            let login :&str = "login";
-            let bio :&str = "bio";
-            let gist_count :&str = "gist-count";
-            let follow_count :&str = "follow-count";
-            let follower_count :&str = "follower-count";
-            let repository_count :&str = "repository-count";
-            let location :&str = "location";
-
-            match &arg {
-                name => json_decoder.name(json),
-                login => json_decoder.login(json),
-                bio => json_decoder.bio(json),
-                gist_count => json_decoder.gist(json),
-                follow_count => json_decoder.follow_count(json),
-                follower_count => json_decoder.follower_count(json),
-                repository_count => json_decoder.repository_count(json),
-                location => json_decoder.location(json),
-            };
+            if arg.starts_with("bio"){
+                json_decoder.bio(json);
+            }else if arg.starts_with("login"){
+                json_decoder.login(json);
+            }else if arg.starts_with("name"){
+                json_decoder.name(json);
+            }else if arg.starts_with("gist-count"){
+                json_decoder.gist(json);
+            }else if arg.starts_with("follow-count"){
+                json_decoder.follow_count(json);
+            }else if arg.starts_with("follower-count"){
+                json_decoder.follower_count(json);
+            }else if arg.starts_with("location"){
+                json_decoder.location(json);
+            }
         }
     }
 }
 fn main(){
     let checkhub = Checkhub::new();
     checkhub.run();
+}
+
+#[test]
+fn test_parse_config(){
+    let yaml = github_api::get_config_yamlfile("apiconfig.yml");
+    let docs = YamlLoader::load_from_str(yaml).unwrap();
+    let doc = &docs[0];
+    println!("{}",yaml);
+    let result = doc["GITHUB_API_TOKEN"].as_str().unwrap();
+    let result2 = doc["name"].as_str().unwrap();
+    let str_result:&str = result;
+    println!("Your API token={}",str_result);
+    println!("Your github login name={}",result2);
+}
+
+// this code from github usage's example
+#[test]
+fn test_parse_yaml_format() {
+    let s =
+    "foo:
+    - list1
+    - list2";
+    // Index access for map & array
+    let result = doc["foo"][0].as_str().unwrap();
+
+    println!("{}",result );
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,33 +44,25 @@ impl Checkhub{
         let maches = tool.get_matches();
       
         if let Some(arg) = maches.value_of("INFO NAME"){
-            if arg == "name"{
-               json_decoder.name(json);
-            }
-            else if arg == "login"{
-               json_decoder.login(json);
-            }
-            else if arg == "bio"{
-               json_decoder.bio(json);
-            }
-            else if arg == "gist-count"{
-               json_decoder.gist(json);
-            }
-            else if arg == "follow-count"{
-               json_decoder.follow_count(json);
-            }
-            else if arg =="follower-count"{
-               json_decoder.follower_count(json);
-            }
-            else if arg == "repository-count"{
-               json_decoder.repository_count(json);
-            }
-            else if arg =="location"{
-               json_decoder.location(json);
-            }
-           else{
-               println!("Undefined args of this tool :{} \nCheck  -h or --help command",arg);
-            }
+            let name :&str = "name";
+            let login :&str = "login";
+            let bio :&str = "bio";
+            let gist_count :&str = "gist-count";
+            let follow_count :&str = "follow-count";
+            let follower_count :&str = "follower-count";
+            let repository_count :&str = "repository-count";
+            let location :&str = "location";
+
+            match &arg {
+                name => json_decoder.name(json),
+                login => json_decoder.login(json),
+                bio => json_decoder.bio(json),
+                gist_count => json_decoder.gist(json),
+                follow_count => json_decoder.follow_count(json),
+                follower_count => json_decoder.follower_count(json),
+                repository_count => json_decoder.repository_count(json),
+                location => json_decoder.location(json),
+            };
         }
     }
 }


### PR DESCRIPTION
#　変更点
- 実行するための設定にymlファイルを使うようにした。
- コマンドライン引数の解析部分をstarts_withを使うように変更した。
```rust
// Before
if arg == "name"{
}
// 以下に変更
if arg.starts_with("name"){
}
```
# このプルリクエストをマージすると？
- 設定にymlを使うようになる。
- CLIツールとしての挙動は変わらない。
# 備考
- 所有権やライフタイム面でよくわかってないところがあり、無理やり実装してしまった部分もあるのので調べて実装しなおしたい。
- ymlファイルの解析にmacroを今後使っていくかどうか検討

以上の二項目はissueにする