### PR TITLE
[Fix] 引数の解析部分 && jsonのgist部分の解析メソッドの名称を変更

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "atty"
-version = "0.2.8"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.39 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -73,7 +73,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "check-hub"
 version = "0.1.0"
 dependencies = [
- "clap 2.31.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "yaml-rust 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -81,16 +81,16 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.31.1"
+version = "2.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "atty 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "atty 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "textwrap 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "vec_map 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "textwrap 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -653,10 +653,10 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -761,7 +761,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -789,7 +789,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "vec_map"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -846,7 +846,7 @@ dependencies = [
 [metadata]
 "checksum adler32 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6cbd0b9af8587c72beadc9f72d35b9fbb070982c9e6203e46e93f10df25f8f45"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
-"checksum atty 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "af80143d6f7608d746df1520709e5d141c96f240b0e62b0aa41bdfb53374d9d4"
+"checksum atty 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)" = "2fc4a1aa4c24c0718a250f0681885c1af91419d242f29eb8f2ab28502d80dbd1"
 "checksum base64 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "229d032f1a99302697f10b27167ae6d03d49d032e6a8e2550e8d3fc13356d2b4"
 "checksum bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4efd02e230a02e18f92fc2735f44597385ed02ad8f831e7c1c1156ee5e1ab3a5"
 "checksum bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b3c30d3802dfb7281680d6285f2ccdaa8c2d8fee41f93805dba5c4cf50dc23cf"
@@ -855,7 +855,7 @@ dependencies = [
 "checksum bytes 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "1b7db437d718977f6dc9b2e3fd6fc343c02ac6b899b73fdd2179163447bd9ce9"
 "checksum cc 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "9be26b24e988625409b19736d130f0c7d224f01d06454b5f81d8d23d6c1a618f"
 "checksum cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d4c819a1287eb618df47cc647173c5c4c66ba19d888a6e50d605672aed3140de"
-"checksum clap 2.31.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5dc18f6f4005132120d9711636b32c46a233fad94df6217fa1d81c5e97a9f200"
+"checksum clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b957d88f4b6a63b9d70d5f454ac8011819c6efa7727858f458ab71c756ce2d3e"
 "checksum core-foundation 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "25bfd746d203017f7d5cbd31ee5d8e17f94b6521c7af77ece6c9e4b2d4b16c67"
 "checksum core-foundation-sys 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "065a5d7ffdcbc8fa145d6f0746f3555025b9097a9e9cda59f7467abae670c78d"
 "checksum crc 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bd5d02c0aac6bd68393ed69e00bbc2457f3e89075c6349db7189618dc4ddc1d7"
@@ -923,7 +923,7 @@ dependencies = [
 "checksum take 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b157868d8ac1f56b64604539990685fa7611d8fa9e5476cf0c02cf34d32917c5"
 "checksum tempdir 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "f73eebdb68c14bcb24aef74ea96079830e7fa7b31a6106e42ea7ee887c1e134e"
 "checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
-"checksum textwrap 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c0b59b6b4b44d867f1370ef1bd91bfb262bf07bf0ae65c202ea2fbc16153b693"
+"checksum textwrap 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "307686869c93e71f94da64286f9a9524c0f308a9e1c87a583de8e9c9039ad3f6"
 "checksum time 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "a15375f1df02096fb3317256ce2cee6a1f42fc84ea5ad5fc8c421cfe40c73098"
 "checksum tokio-core 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "52b4e32d8edbf29501aabb3570f027c6ceb00ccef6538f4bddba0200503e74e8"
 "checksum tokio-io 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "b9532748772222bf70297ec0e2ad0f17213b4a7dd0e6afb68e0a0768f69f4e4f"
@@ -934,11 +934,11 @@ dependencies = [
 "checksum unicase 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "284b6d3db520d67fbe88fd778c21510d1b0ba4a551e5d0fbb023d33405f6de8a"
 "checksum unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
 "checksum unicode-normalization 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "51ccda9ef9efa3f7ef5d91e8f9b83bbe6955f9bf86aec89d5cce2c874625920f"
-"checksum unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "bf3a113775714a22dcb774d8ea3655c53a32debae63a063acc00a91cc586245f"
+"checksum unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "882386231c45df4700b275c7ff55b6f3698780a650026380e72dabe76fa46526"
 "checksum url 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f808aadd8cfec6ef90e4a14eb46f24511824d1ac596b9682703c87056c8678b7"
 "checksum uuid 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bcc7e3b898aa6f6c08e5295b6c89258d1331e9ac578cc992fb818759951bdc22"
 "checksum vcpkg 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9e0a7d8bed3178a8fb112199d466eeca9ed09a14ba8ad67718179b4fd5487d0b"
-"checksum vec_map 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "887b5b631c2ad01628bbbaa7dd4c869f80d3186688f8d0b6f58774fbe324988c"
+"checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 "checksum version_check 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6b772017e347561807c1aa192438c5fd74242a670a6cffacc40f2defd1dc069d"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "04e3bd221fcbe8a271359c04f21a76db7d0c6028862d1bb5512d85e1e2eb5bb3"

--- a/apiconfig.yml
+++ b/apiconfig.yml
@@ -1,0 +1,2 @@
+name: ItinoseSan
+GITHUB_API_TOKEN: 8cd4f6f4c5fd0633b5ac3ba7c970648b8868c889

--- a/apiconfig.yml
+++ b/apiconfig.yml
@@ -1,2 +1,0 @@
-name: ItinoseSan
-GITHUB_API_TOKEN: 8cd4f6f4c5fd0633b5ac3ba7c970648b8868c889

--- a/src/github_api.rs
+++ b/src/github_api.rs
@@ -1,8 +1,7 @@
 extern crate yaml_rust;
-use yaml_rust::{YamlLoader, YamlEmitter};
+use yaml_rust::YamlLoader;
 
 use std::mem;
-use std::fs;
 use std::fs::File;
 use std::io::Read;
 

--- a/src/json.rs
+++ b/src/json.rs
@@ -27,7 +27,7 @@ impl JSON{
         println!("Your location is {}",parser["location"]);
         Ok(())
     }
-    pub fn gist(&self, json: &str)-> Result<(), Error>{
+    pub fn gist_count(&self, json: &str)-> Result<(), Error>{
         let parser: Value = serde_json::from_str(json)?;
         println!("Your gist count is {}",parser["public_gists"]);
         Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,13 +4,13 @@ extern crate reqwest;
 mod github_api;
 mod http;
 mod json;
-use clap::{ App, Arg };
+use clap::{ App,SubCommand };
 use github_api::GithubAPI;
 use http::HttpRequest;
 use json::JSON;
 
 extern crate yaml_rust;
-use yaml_rust::{YamlLoader, YamlEmitter};
+use yaml_rust::YamlLoader;
 
 pub struct Checkhub{}
 
@@ -24,7 +24,6 @@ impl Checkhub{
         .author("Itinose <dhelitus@gmail.com>")
         .about("CLI tool which can check github user informations")
         .usage("./check-hub [INFO NAME]")
-        .arg(Arg::with_name("INFO NAME")
         .help("GitHub user informations(current version supporting)
         - name 
         - login
@@ -33,37 +32,34 @@ impl Checkhub{
         - follow-count
         - follower-count
         - location") 
-       .required(true)          
-    );
-    self.parse_argument(tool);      
-    }                                                    
-    fn parse_argument(&self,tool: App){
+        .subcommand(SubCommand::with_name("name"))
+        .subcommand(SubCommand::with_name("login"))
+        .subcommand(SubCommand::with_name("bio"))
+        .subcommand(SubCommand::with_name("gist-count"))
+        .subcommand(SubCommand::with_name("follow-count"))
+        .subcommand(SubCommand::with_name("follower-count"))
+        .subcommand(SubCommand::with_name("location"))        
+        .get_matches();
+
         let github = GithubAPI::new();
         let client = HttpRequest::new();
         let url = github.profile();
         let json = client.get_request_json(url);
         let json_decoder = JSON::new();
-        let maches = tool.get_matches();
-      
-        if let Some(arg) = maches.value_of("INFO NAME"){
-            if arg.starts_with("bio"){
-                json_decoder.bio(json);
-            }else if arg.starts_with("login"){
-                json_decoder.login(json);
-            }else if arg.starts_with("name"){
-                json_decoder.name(json);
-            }else if arg.starts_with("gist-count"){
-                json_decoder.gist(json);
-            }else if arg.starts_with("follow-count"){
-                json_decoder.follow_count(json);
-            }else if arg.starts_with("follower-count"){
-                json_decoder.follower_count(json);
-            }else if arg.starts_with("location"){
-                json_decoder.location(json);
-            }
+
+        match tool.subcommand_name(){
+            Some("name") => { json_decoder.name(json); },
+            Some("login") => { json_decoder.login(json); },
+            Some("bio") => { json_decoder.bio(json); },
+            Some("gist-count") => { json_decoder.gist_count(json); },
+            Some("follow-count") => { json_decoder.follow_count(json); },
+            Some("follower-count") => { json_decoder.follower_count(json); },
+            Some("location") => { json_decoder.location(json); },            
+            _ => { println!("Error: You must input subcommand. Please check --help command");}
         }
-    }
-}
+    }    
+}        
+
 fn main(){
     let checkhub = Checkhub::new();
     checkhub.run();
@@ -80,17 +76,4 @@ fn test_parse_config(){
     let str_result:&str = result;
     println!("Your API token={}",str_result);
     println!("Your github login name={}",result2);
-}
-
-// this code from github usage's example
-#[test]
-fn test_parse_yaml_format() {
-    let s =
-    "foo:
-    - list1
-    - list2";
-    // Index access for map & array
-    let result = doc["foo"][0].as_str().unwrap();
-
-    println!("{}",result );
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,13 +48,13 @@ impl Checkhub{
         let json_decoder = JSON::new();
 
         match tool.subcommand_name(){
-            Some("name") => { json_decoder.name(json); },
-            Some("login") => { json_decoder.login(json); },
-            Some("bio") => { json_decoder.bio(json); },
-            Some("gist-count") => { json_decoder.gist_count(json); },
-            Some("follow-count") => { json_decoder.follow_count(json); },
+            Some("name")           => { json_decoder.name(json); },
+            Some("login")          => { json_decoder.login(json); },
+            Some("bio")            => { json_decoder.bio(json); },
+            Some("gist-count")     => { json_decoder.gist_count(json); },
+            Some("follow-count")   => { json_decoder.follow_count(json); },
             Some("follower-count") => { json_decoder.follower_count(json); },
-            Some("location") => { json_decoder.location(json); },            
+            Some("location") 　　　 => { json_decoder.location(json); },            
             _ => { println!("Error: You must input subcommand. Please check --help command");}
         }
     }    


### PR DESCRIPTION
# 変更
- 引数の解析部分をsubcommandで定義してmatch文で解析するようにした。
- jsonの解析でgistのカウント数の部分解析をするメソッドの名前を```gist →gist_count```に変更
# 備考
前のコミットで誤ってAPIトークンをコミットしてしまったので無効にした。